### PR TITLE
Bugfix if root has only outgoing edges

### DIFF
--- a/edmonds/edmonds.py
+++ b/edmonds/edmonds.py
@@ -135,9 +135,8 @@ def mst(root,G):
     """
 
     RG = _reverse(G)
-    if root not in RG:
-        return None
-    RG[root].clear()
+    if root in RG:
+        RG[root] = {}
     g = {}
     for n in RG:
         if len(RG[n]) == 0:


### PR DESCRIPTION
Hi,
This should fix the mst if the input graph has only outgoing edges.
for example
g={1: {2: 1, 3: 15}, 2: {3: 2}, 3: {}}
mst(1,g) should return {1: {2: 1}, 2: {3: 2}} not None

Thanks for the algorithm.
